### PR TITLE
Sync dev → main: branching convention in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Four layers, in dependency order:
 
 ## Conventions
 
+- **Branching:** `main` is the stable branch. All day-to-day work happens on `dev` — agents and contributors branch from and merge into `dev` by default. `dev` merges into `main` via PR at meaningful milestones. Never commit directly to `main`.
 - **Schema documents:** JSON, validated against the spec; files use the `.muse.json` extension (once examples/tooling land).
 - **Spec edits:** keep the changelog discipline — `muse_version` is semver; v0.x may break, v1+ additive only.
 - **Code style:** minimal comments; comment only non-obvious invariants or deliberate tradeoffs. Keep changes focused and small.


### PR DESCRIPTION
First milestone sync of `dev` into `main`.

## Changes

- **AGENTS.md**: documents the branching convention — `main` is stable, day-to-day work happens on `dev`, `dev` merges into `main` via PR at meaningful milestones, never commit directly to `main`.

## Context

This is the only commit `dev` is ahead of `main`. After this merges, both branches will be in sync and future milestone PRs will follow the same path.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@allenpd728 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/472c3dff-9ec6-4ae5-bfe9-94116b2502e7)